### PR TITLE
fix: handle existing OAuth clients during client creation

### DIFF
--- a/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
+++ b/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
@@ -1,8 +1,10 @@
 package no.fintlabs.portal.oauth;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import no.fintlabs.portal.exceptions.ObjectNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -10,11 +12,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PostConstruct;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @Slf4j
@@ -56,19 +61,15 @@ public class NamOAuthClientService {
 
     public OAuthClient addOAuthClient(String name) {
         log.info("Adding client {}...", name);
-        OAuthClient oAuthClient = new OAuthClient(name);
-        String jsonOAuthClient = null;
+        HttpEntity<String> request;
 
         try {
-            jsonOAuthClient = mapper.writeValueAsString(oAuthClient);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            request = new HttpEntity<>(mapper.writeValueAsString(new OAuthClient(name)), headers);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("Unable to serialize OAuth client request", e);
         }
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        HttpEntity<String> request = new HttpEntity<>(jsonOAuthClient, headers);
 
         try {
             var url = String.format(NamOAuthConstants.CLIENT_REGISTRATION_URL_TEMPLATE, idpHostname);
@@ -76,6 +77,13 @@ public class NamOAuthClientService {
             OAuthClient client = mapper.readValue(response, OAuthClient.class);
             log.info("Client ID {} created.", client.getClientId());
             return client;
+        } catch (InvalidClientException e) {
+            if (clientAlreadyExists(e)) {
+                return getOauthClientByName(name);
+            }
+            throw e;
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Unable to deserialize OAuth client creation response", e);
         } catch (Exception e) {
             log.error("Unable to create client {}", name, e);
             throw new RuntimeException(e);
@@ -113,11 +121,38 @@ public class NamOAuthClientService {
         }
     }
 
+    public OAuthClient getOauthClientByName(String name) {
+        log.info("Fetching client by name {}...", name);
+
+        try {
+            var url = String.format(NamOAuthConstants.CLIENT_LIST_URL_TEMPLATE, idpHostname);
+            String response = restTemplate.getForObject(url, String.class);
+            List<OAuthClient> clients = mapper.readValue(response, new TypeReference<>() {
+            });
+
+            return clients.stream()
+                    .filter(client -> Objects.equals(name, client.getClientName()))
+                    .findFirst()
+                    .orElseThrow(() -> new ObjectNotFoundException(
+                            String.format("OAuth client with name '%s' was not found", name)
+                    ));
+        } catch (ObjectNotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Unable to get client by name {}", name, e);
+            throw new RuntimeException(e);
+        }
+    }
+
     private void sleep(int i) {
         try {
             Thread.sleep(i * i * RETRY_SLEEP_MS);
         } catch (InterruptedException ex) {
             log.debug("Usually doesn't happen", ex);
         }
+    }
+
+    private boolean clientAlreadyExists(InvalidClientException e) {
+        return e.getMessage() != null && e.getMessage().startsWith("The client already exists");
     }
 }

--- a/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
+++ b/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
@@ -79,7 +79,7 @@ public class NamOAuthClientService {
             return client;
         } catch (InvalidClientException e) {
             if (clientAlreadyExists(e)) {
-                return getOauthClientByName(name);
+                return getOAuthClientByName(name);
             }
             throw e;
         } catch (JsonProcessingException e) {
@@ -121,7 +121,7 @@ public class NamOAuthClientService {
         }
     }
 
-    public OAuthClient getOauthClientByName(String name) {
+    public OAuthClient getOAuthClientByName(String name) {
         log.info("Fetching client by name {}...", name);
 
         try {

--- a/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
+++ b/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
@@ -68,6 +68,7 @@ public class NamOAuthClientService {
             headers.setContentType(MediaType.APPLICATION_JSON);
             request = new HttpEntity<>(mapper.writeValueAsString(new OAuthClient(name)), headers);
         } catch (JsonProcessingException e) {
+            log.error("Unable to serialize OAuth client request for {}", name, e);
             throw new IllegalStateException("Unable to serialize OAuth client request", e);
         }
 
@@ -81,8 +82,10 @@ public class NamOAuthClientService {
             if (clientAlreadyExists(e)) {
                 return getOAuthClientByName(name);
             }
+            log.error("Unable to create client {}", name, e);
             throw e;
         } catch (JsonProcessingException e) {
+            log.error("Unable to deserialize OAuth client creation response for {}", name, e);
             throw new IllegalStateException("Unable to deserialize OAuth client creation response", e);
         } catch (Exception e) {
             log.error("Unable to create client {}", name, e);
@@ -108,14 +111,12 @@ public class NamOAuthClientService {
                 var url = String.format(NamOAuthConstants.CLIENT_URL_TEMPLATE, idpHostname);
                 return restTemplate.getForObject(url, OAuthClient.class, clientId);
             } catch (Exception e) {
-                log.warn("Unable to get client {}, this was iteration number {}", clientId, i);
-                log.warn("Error, will retry: " + e.getMessage());
-
                 if (i == RETRY_ATTEMPTS) {
-                    log.error("Failed to getOauthClient after max retry attempts. Giving up", e);
+                    log.error("Unable to get client {} after {} attempts", clientId, RETRY_ATTEMPTS, e);
                     throw e;
                 }
 
+                log.warn("Unable to get client {} on attempt {} of {}, retrying", clientId, i, RETRY_ATTEMPTS, e);
                 sleep(i);
             }
         }
@@ -136,6 +137,9 @@ public class NamOAuthClientService {
                     .orElseThrow(() -> new ObjectNotFoundException(
                             String.format("OAuth client with name '%s' was not found", name)
                     ));
+        } catch (ObjectNotFoundException e) {
+            log.error("Unable to get client by name {}", name, e);
+            throw e;
         } catch (Exception e) {
             log.error("Unable to get client by name {}", name, e);
             throw new RuntimeException(e);

--- a/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
+++ b/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
@@ -127,7 +127,7 @@ public class NamOAuthClientService {
         try {
             var url = String.format(NamOAuthConstants.CLIENT_LIST_URL_TEMPLATE, idpHostname);
             String response = restTemplate.getForObject(url, String.class);
-            List<OAuthClient> clients = mapper.readValue(response, new TypeReference<>() {
+            List<OAuthClient> clients = mapper.readValue(response, new TypeReference<List<OAuthClient>>() {
             });
 
             return clients.stream()

--- a/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
+++ b/src/main/java/no/fintlabs/portal/oauth/NamOAuthClientService.java
@@ -136,8 +136,6 @@ public class NamOAuthClientService {
                     .orElseThrow(() -> new ObjectNotFoundException(
                             String.format("OAuth client with name '%s' was not found", name)
                     ));
-        } catch (ObjectNotFoundException e) {
-            throw e;
         } catch (Exception e) {
             log.error("Unable to get client by name {}", name, e);
             throw new RuntimeException(e);

--- a/src/main/java/no/fintlabs/portal/oauth/NamOAuthConstants.java
+++ b/src/main/java/no/fintlabs/portal/oauth/NamOAuthConstants.java
@@ -11,6 +11,7 @@ public class NamOAuthConstants {
     public static final String PASSWORD_GRANT_TYPE = "password";
     public static final String ACCESS_TOKEN_URL_TEMPLATE = "https://%s//nidp/oauth/nam/token";
     public static final String CLIENT_REGISTRATION_URL_TEMPLATE = "http://%s/nidp/oauth/nam/clients/";
+    public static final String CLIENT_LIST_URL_TEMPLATE = "http://%s/nidp/oauth/nam/clients";
     public static final String CLIENT_URL_TEMPLATE = "http://%s/nidp/oauth/nam/clients/{clientId}";
     public static final String APPLICATION_TYPE = "web";
 

--- a/src/test/groovy/no/fintlabs/portal/oauth/NamOAuthClientServiceSpec.groovy
+++ b/src/test/groovy/no/fintlabs/portal/oauth/NamOAuthClientServiceSpec.groovy
@@ -34,7 +34,7 @@ class NamOAuthClientServiceSpec extends Specification {
     def "Get OAuth Client By Name"() {
 
         when:
-        def client = namOAuthClientService.getOauthClientByName("target-client")
+        def client = namOAuthClientService.getOAuthClientByName("target-client")
 
         then:
         1 * restTemplate.getForObject(_ as String, String.class) >> """[
@@ -50,7 +50,7 @@ class NamOAuthClientServiceSpec extends Specification {
     def "Get OAuth Client By Name throws when client is missing"() {
 
         when:
-        namOAuthClientService.getOauthClientByName("missing-client")
+        namOAuthClientService.getOAuthClientByName("missing-client")
 
         then:
         1 * restTemplate.getForObject(_ as String, String.class) >> """[

--- a/src/test/groovy/no/fintlabs/portal/oauth/NamOAuthClientServiceSpec.groovy
+++ b/src/test/groovy/no/fintlabs/portal/oauth/NamOAuthClientServiceSpec.groovy
@@ -1,8 +1,10 @@
 package no.fintlabs.portal.oauth
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import no.fintlabs.portal.exceptions.ObjectNotFoundException
 import org.springframework.http.HttpEntity
 import org.springframework.security.oauth2.client.OAuth2RestTemplate
+import org.springframework.security.oauth2.common.exceptions.InvalidClientException
 import spock.lang.Specification
 
 class NamOAuthClientServiceSpec extends Specification {
@@ -27,5 +29,52 @@ class NamOAuthClientServiceSpec extends Specification {
         client != null
         !client.getClientId().isEmpty()
         !client.getClientSecret().isEmpty()
+    }
+
+    def "Get OAuth Client By Name"() {
+
+        when:
+        def client = namOAuthClientService.getOauthClientByName("target-client")
+
+        then:
+        1 * restTemplate.getForObject(_ as String, String.class) >> """[
+            {"client_name":"other-client","client_id":"other-id","client_secret":"other-secret"},
+            {"client_name":"target-client","client_id":"target-id","client_secret":"target-secret"}
+        ]"""
+        client != null
+        client.getClientName() == "target-client"
+        client.getClientId() == "target-id"
+        client.getClientSecret() == "target-secret"
+    }
+
+    def "Get OAuth Client By Name throws when client is missing"() {
+
+        when:
+        namOAuthClientService.getOauthClientByName("missing-client")
+
+        then:
+        1 * restTemplate.getForObject(_ as String, String.class) >> """[
+            {"client_name":"other-client","client_id":"other-id","client_secret":"other-secret"}
+        ]"""
+        def e = thrown(ObjectNotFoundException)
+        e.message == "OAuth client with name 'missing-client' was not found"
+    }
+
+    def "Add OAuth Client returns existing client when NAM says it already exists"() {
+
+        when:
+        def client = namOAuthClientService.addOAuthClient("existing-client")
+
+        then:
+        1 * restTemplate.postForObject(_ as String, _ as HttpEntity, _ as Class) >> {
+            throw new InvalidClientException("The client already exists")
+        }
+        1 * restTemplate.getForObject(_ as String, String.class) >> """[
+            {"client_name":"existing-client","client_id":"existing-id","client_secret":"existing-secret"}
+        ]"""
+        client != null
+        client.getClientName() == "existing-client"
+        client.getClientId() == "existing-id"
+        client.getClientSecret() == "existing-secret"
     }
 }


### PR DESCRIPTION
This PR fixes an error in the OAuth client creation flow where we try to create a client that already exists.

Instead of failing in that case, we now look up the existing client and return it. This makes the client creation flow handle already-existing clients correctly.

